### PR TITLE
Fix Issue #2296

### DIFF
--- a/scripts/redis-info.nse
+++ b/scripts/redis-info.nse
@@ -136,7 +136,9 @@ local extras = {
       local client_ips = {}
       for _, item in ipairs(restab) do
         local ip = item:match("addr=%[?([0-9a-f:.]+)%]?:[0-9]+ ")
+        if not item or 0 == #item then goto continue end
         client_ips[ip] = true;
+        ::continue:
       end
       if not next(client_ips) then
         return nil


### PR DESCRIPTION
fixes #2296

When the item doesn't exist the script fails and results in "ERROR: Script execution failed (use -d to debug)" as the script output. This patch simply skips over the non-existent item and continues the loop.